### PR TITLE
fix(binary): change the binary name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+kairos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "Kairos"
+name = "kairos"
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Kairos"
+name = "kairos"
 version = "0.1.0"
 edition = "2021"
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 MAIN		= 		src/main.rs
 
-NAME   		=		Kairos
+NAME   		=		kairos
 
 CC 			= 		cargo build
 


### PR DESCRIPTION
Fix the binary name, its better for the project to have a binary name in lowercase. The name have been changed in the .toml file and in the 'Makefile'.

Add the binary in the '.gitignore'.

Deniz Uzuntok Husson
deniz.uzuntok-husson@epitech.eu